### PR TITLE
feat: Adiciona navegação consistente entre as páginas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Dependencies #
+################
+node_modules/

--- a/QuizExp.html
+++ b/QuizExp.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Quiz de Nutrição Experimental</title>
+    <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
     <style>
         body {
@@ -170,6 +171,32 @@
     </style>
 </head>
 <body>
+    <header class="bg-white dark:bg-slate-800 shadow-md mb-8">
+        <nav class="container mx-auto px-6 py-4">
+            <div class="flex items-center justify-between">
+                <div class="text-2xl font-bold text-indigo-600 dark:text-indigo-400">
+                    <a href="index.html">O Nutri Giu</a>
+                </div>
+                <div class="hidden md:flex items-center space-x-4">
+                    <a href="index.html" class="px-4 py-2 text-gray-700 dark:text-gray-200 hover:text-indigo-600 dark:hover:text-indigo-400 font-semibold rounded-lg hover:bg-gray-100 dark:hover:bg-slate-700">Calculadora</a>
+                    <a href="QuizExp.html" class="px-4 py-2 text-gray-700 dark:text-gray-200 hover:text-indigo-600 dark:hover:text-indigo-400 font-semibold rounded-lg bg-gray-100 dark:bg-slate-700">Quiz Experimental</a>
+                    <a href="QuizNutHosp.html" class="px-4 py-2 text-gray-700 dark:text-gray-200 hover:text-indigo-600 dark:hover:text-indigo-400 font-semibold rounded-lg hover:bg-gray-100 dark:hover:bg-slate-700">Quiz Hospitalar</a>
+                </div>
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="text-gray-700 dark:text-gray-200 focus:outline-none">
+                        <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+            <div id="mobile-menu" class="hidden md:hidden mt-4">
+                <a href="index.html" class="block py-2 px-4 text-sm text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-700">Calculadora</a>
+                <a href="QuizExp.html" class="block py-2 px-4 text-sm text-gray-700 dark:text-gray-200 rounded-lg bg-gray-100 dark:bg-slate-700">Quiz Experimental</a>
+                <a href="QuizNutHosp.html" class="block py-2 px-4 text-sm text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-700">Quiz Hospitalar</a>
+            </div>
+        </nav>
+    </header>
     <div class="container">
         <h1>Quiz de Nutrição Experimental</h1>
         <div class="header">
@@ -680,6 +707,11 @@
         // Iniciar temporizador e carregar questões
         updateTimer();
         loadQuestions();
+
+        document.getElementById('mobile-menu-button').addEventListener('click', function() {
+            var menu = document.getElementById('mobile-menu');
+            menu.classList.toggle('hidden');
+        });
     </script>
 </body>
 </html>

--- a/QuizNutHosp.html
+++ b/QuizNutHosp.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Quiz Nutrição Hospitalar</title>
+    <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
@@ -207,6 +208,7 @@
         .modal-buttons { margin-top: 1.5rem; display: flex; gap: 1rem; justify-content: center; }
 
         /* --- Responsive Design --- */
+
         @media (max-width: 1024px) {
             #sidebar { transform: translateX(-100%); }
             #sidebar.open { transform: translateX(0); }
@@ -249,8 +251,34 @@
     </div>
 
     <div class="page-content">
+        <header class="bg-white dark:bg-slate-800 shadow-md mb-8">
+            <nav class="container mx-auto px-6 py-4">
+                <div class="flex items-center justify-between">
+                    <div class="text-2xl font-bold text-indigo-600 dark:text-indigo-400">
+                        <a href="index.html">O Nutri Giu</a>
+                    </div>
+                    <div class="hidden md:flex items-center space-x-4">
+                        <a href="index.html" class="px-4 py-2 text-gray-700 dark:text-gray-200 hover:text-indigo-600 dark:hover:text-indigo-400 font-semibold rounded-lg hover:bg-gray-100 dark:hover:bg-slate-700">Calculadora</a>
+                        <a href="QuizExp.html" class="px-4 py-2 text-gray-700 dark:text-gray-200 hover:text-indigo-600 dark:hover:text-indigo-400 font-semibold rounded-lg hover:bg-gray-100 dark:hover:bg-slate-700">Quiz Experimental</a>
+                        <a href="QuizNutHosp.html" class="px-4 py-2 text-gray-700 dark:text-gray-200 hover:text-indigo-600 dark:hover:text-indigo-400 font-semibold rounded-lg bg-gray-100 dark:bg-slate-700">Quiz Hospitalar</a>
+                    </div>
+                    <div class="md:hidden">
+                        <button id="mobile-menu-button" class="text-gray-700 dark:text-gray-200 focus:outline-none">
+                            <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path>
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+                <div id="mobile-menu" class="hidden md:hidden mt-4">
+                    <a href="index.html" class="block py-2 px-4 text-sm text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-700">Calculadora</a>
+                    <a href="QuizExp.html" class="block py-2 px-4 text-sm text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-700">Quiz Experimental</a>
+                    <a href="QuizNutHosp.html" class="block py-2 px-4 text-sm text-gray-700 dark:text-gray-200 rounded-lg bg-gray-100 dark:bg-slate-700">Quiz Hospitalar</a>
+                </div>
+            </nav>
+        </header>
         <div id="header-container">
-            <div id="theme-switcher">
+             <div id="theme-switcher">
                 <label class="switch">
                     <input type="checkbox" id="dark-mode-toggle">
                     <span class="slider"></span>
@@ -785,6 +813,11 @@
             const theme = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
             localStorage.setItem('quizTheme', theme);
         }
+
+        document.getElementById('mobile-menu-button').addEventListener('click', function() {
+            var menu = document.getElementById('mobile-menu');
+            menu.classList.toggle('hidden');
+        });
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -230,6 +230,33 @@
 </head>
 <body class="antialiased">
 
+    <header class="bg-white dark:bg-slate-800 shadow-md mb-8">
+        <nav class="container mx-auto px-6 py-4">
+            <div class="flex items-center justify-between">
+                <div class="text-2xl font-bold text-indigo-600 dark:text-indigo-400">
+                    <a href="index.html">O Nutri Giu</a>
+                </div>
+                <div class="hidden md:flex items-center space-x-4">
+                    <a href="index.html" class="px-4 py-2 text-gray-700 dark:text-gray-200 hover:text-indigo-600 dark:hover:text-indigo-400 font-semibold rounded-lg bg-gray-100 dark:bg-slate-700">Calculadora</a>
+                    <a href="QuizExp.html" class="px-4 py-2 text-gray-700 dark:text-gray-200 hover:text-indigo-600 dark:hover:text-indigo-400 font-semibold rounded-lg hover:bg-gray-100 dark:hover:bg-slate-700">Quiz Experimental</a>
+                    <a href="QuizNutHosp.html" class="px-4 py-2 text-gray-700 dark:text-gray-200 hover:text-indigo-600 dark:hover:text-indigo-400 font-semibold rounded-lg hover:bg-gray-100 dark:hover:bg-slate-700">Quiz Hospitalar</a>
+                </div>
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="text-gray-700 dark:text-gray-200 focus:outline-none">
+                        <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+            <div id="mobile-menu" class="hidden md:hidden mt-4">
+                <a href="index.html" class="block py-2 px-4 text-sm text-gray-700 dark:text-gray-200 rounded-lg bg-gray-100 dark:bg-slate-700">Calculadora</a>
+                <a href="QuizExp.html" class="block py-2 px-4 text-sm text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-700">Quiz Experimental</a>
+                <a href="QuizNutHosp.html" class="block py-2 px-4 text-sm text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-700">Quiz Hospitalar</a>
+            </div>
+        </nav>
+    </header>
+
     <div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-7xl">
         
         <div class="flex justify-between items-center mb-6">
@@ -981,6 +1008,10 @@
             for(let i=0; i<4; i++) addRow();
             document.querySelectorAll(".btn").forEach(button => {
                 button.addEventListener("click", createRipple);
+            });
+            document.getElementById('mobile-menu-button').addEventListener('click', function() {
+                var menu = document.getElementById('mobile-menu');
+                menu.classList.toggle('hidden');
             });
         };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,71 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@playwright/test": "^1.56.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@playwright/test": "^1.56.1"
+  }
+}

--- a/playwright_report.json
+++ b/playwright_report.json
@@ -1,0 +1,172 @@
+{
+  "config": {
+    "rootDir": "/app",
+    "forbidOnly": false,
+    "fullyParallel": false,
+    "globalSetup": null,
+    "globalTeardown": null,
+    "globalTimeout": 0,
+    "grep": {},
+    "grepInvert": null,
+    "maxFailures": 0,
+    "metadata": {
+      "actualWorkers": 1
+    },
+    "preserveOutput": "always",
+    "reporter": [
+      [
+        "json"
+      ]
+    ],
+    "reportSlowTests": {
+      "max": 5,
+      "threshold": 300000
+    },
+    "quiet": false,
+    "projects": [
+      {
+        "outputDir": "/app/test-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "actualWorkers": 1
+        },
+        "id": "",
+        "name": "",
+        "testDir": "/app",
+        "testIgnore": [],
+        "testMatch": [
+          "**/*.@(spec|test).?(c|m)[jt]s?(x)"
+        ],
+        "timeout": 30000
+      }
+    ],
+    "shard": null,
+    "updateSnapshots": "missing",
+    "updateSourceMethod": "patch",
+    "version": "1.56.1",
+    "workers": 2,
+    "webServer": null
+  },
+  "suites": [
+    {
+      "title": "verification.spec.js",
+      "file": "verification.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [
+        {
+          "title": "homepage",
+          "ok": true,
+          "tags": [],
+          "tests": [
+            {
+              "timeout": 30000,
+              "annotations": [],
+              "expectedStatus": "passed",
+              "projectId": "",
+              "projectName": "",
+              "results": [
+                {
+                  "workerIndex": 0,
+                  "parallelIndex": 0,
+                  "status": "passed",
+                  "duration": 1003,
+                  "errors": [],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 0,
+                  "startTime": "2025-11-04T23:53:29.367Z",
+                  "annotations": [],
+                  "attachments": []
+                }
+              ],
+              "status": "expected"
+            }
+          ],
+          "id": "ae03d26de3effc210ade-71f9c2212a8a67e75ed0",
+          "file": "verification.spec.js",
+          "line": 3,
+          "column": 1
+        },
+        {
+          "title": "quizexp",
+          "ok": true,
+          "tags": [],
+          "tests": [
+            {
+              "timeout": 30000,
+              "annotations": [],
+              "expectedStatus": "passed",
+              "projectId": "",
+              "projectName": "",
+              "results": [
+                {
+                  "workerIndex": 0,
+                  "parallelIndex": 0,
+                  "status": "passed",
+                  "duration": 776,
+                  "errors": [],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 0,
+                  "startTime": "2025-11-04T23:53:30.602Z",
+                  "annotations": [],
+                  "attachments": []
+                }
+              ],
+              "status": "expected"
+            }
+          ],
+          "id": "ae03d26de3effc210ade-44c07ec08f477655d46b",
+          "file": "verification.spec.js",
+          "line": 8,
+          "column": 1
+        },
+        {
+          "title": "quiznuthosp",
+          "ok": true,
+          "tags": [],
+          "tests": [
+            {
+              "timeout": 30000,
+              "annotations": [],
+              "expectedStatus": "passed",
+              "projectId": "",
+              "projectName": "",
+              "results": [
+                {
+                  "workerIndex": 0,
+                  "parallelIndex": 0,
+                  "status": "passed",
+                  "duration": 822,
+                  "errors": [],
+                  "stdout": [],
+                  "stderr": [],
+                  "retry": 0,
+                  "startTime": "2025-11-04T23:53:31.404Z",
+                  "annotations": [],
+                  "attachments": []
+                }
+              ],
+              "status": "expected"
+            }
+          ],
+          "id": "ae03d26de3effc210ade-ff1b27a05c823bc21436",
+          "file": "verification.spec.js",
+          "line": 13,
+          "column": 1
+        }
+      ]
+    }
+  ],
+  "errors": [],
+  "stats": {
+    "startTime": "2025-11-04T23:53:28.243Z",
+    "duration": 4070.8190000000004,
+    "expected": 3,
+    "skipped": 0,
+    "unexpected": 0,
+    "flaky": 0
+  }
+}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/verification.spec.js
+++ b/verification.spec.js
@@ -1,0 +1,16 @@
+const { test, expect } = require('@playwright/test');
+
+test('homepage', async ({ page }) => {
+  await page.goto('file:///app/index.html');
+  await page.screenshot({ path: '/home/jules/verification/index.png' });
+});
+
+test('quizexp', async ({ page }) => {
+  await page.goto('file:///app/QuizExp.html');
+  await page.screenshot({ path: '/home/jules/verification/QuizExp.png' });
+});
+
+test('quiznuthosp', async ({ page }) => {
+  await page.goto('file:///app/QuizNutHosp.html');
+  await page.screenshot({ path: '/home/jules/verification/QuizNutHosp.png' });
+});


### PR DESCRIPTION
Adiciona um cabeçalho de navegação padronizado em `index.html`, `QuizExp.html` e `QuizNutHosp.html`, permitindo que os usuários naveguem facilmente entre a calculadora e os dois quizzes.

Refatora o cabeçalho existente para usar uma única implementação de menu responsivo e CSS, garantindo uma experiência de usuário consistente em todas as páginas. Corrige problemas de capacidade de resposta e inconsistências de estilo que foram identificados em uma revisão anterior.